### PR TITLE
Add scroll controllers for inspection form steps

### DIFF
--- a/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
+++ b/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:provider/provider.dart';
 
 import '../data/guided_steps.dart';
+import '../data/inspections_repository.dart';
 import '../data/models.dart';
 import 'widgets/photo_annotation_screen.dart';
 
@@ -42,6 +44,7 @@ class _InspectionFormScreenState extends State<InspectionFormScreen> {
   final Map<String, List<String>> _stepPhotos = <String, List<String>>{};
   final Map<String, TextEditingController> _stepNotesControllers = <String, TextEditingController>{};
   final Map<String, Set<int>> _instructionCompletion = <String, Set<int>>{};
+  final Map<String, ScrollController> _stepScrollControllers = <String, ScrollController>{};
   final Map<String, bool> _operationalChecks = <String, bool>{
     'brake_test': false,
     'steering_check': false,

--- a/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
+++ b/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
@@ -806,6 +806,10 @@ class _InspectionFormScreenState extends State<InspectionFormScreen> {
     });
   }
 
+  ScrollController _scrollControllerFor(String stepCode) {
+    return _stepScrollControllers.putIfAbsent(stepCode, () => ScrollController());
+  }
+
   Set<int> _instructionStateFor(_GuidedStep step) {
     final completion = _instructionCompletion[step.definition.code];
     return completion == null ? <int>{} : Set<int>.from(completion);

--- a/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
+++ b/flutterapp/lib/features/inspections/presentation/inspection_form_screen.dart
@@ -104,6 +104,9 @@ class _InspectionFormScreenState extends State<InspectionFormScreen> {
     for (final controller in _stepNotesControllers.values) {
       controller.dispose();
     }
+    for (final controller in _stepScrollControllers.values) {
+      controller.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
## Changes Made

### Import Updates
- Reordered imports to follow Dart conventions (foundation before material)
- Added `package:provider/provider.dart` import

### New State Management
- Added `_stepScrollControllers` map to manage `ScrollController` instances for each inspection step
- Implemented `_scrollControllerFor()` method to create and retrieve scroll controllers using `putIfAbsent()`

### Memory Management
- Added proper disposal of scroll controllers in the `dispose()` method to prevent memory leaks

### Additional Imports
- Added `../data/inspections_repository.dart` import for repository access

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/671c946078d44f7a8988058ab3736184/orbit-landing)

👀 [Preview Link](https://671c946078d44f7a8988058ab3736184-orbit-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>671c946078d44f7a8988058ab3736184</projectId>-->
<!--<branchName>orbit-landing</branchName>-->